### PR TITLE
Changed address property to type "string"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ Example config:
 }
 ```
 
+If the i2c address of the LCD Display Module is different from the default address `0x27`, the `address` property 
+needs to be set. If the address of the module is unknown the `i2cdetect` tool can be used which is part 
+of the `i2c-tools` package on Raspbian. 
+Note, the addresses output by the tool are hexadecimal numbers. To set the address property of the plugin 
+accordingly, the number has to be provided as a string preceded by '0x'.
+
+```json
+{
+  "plugin": "lcd",
+  "bus": "/dev/i2c-1",
+  "address": "0x23"
+  "rows": 4,
+  "cols": 20
+}
+```
+
+
 Example rules:
 --------------
 
@@ -28,7 +45,7 @@ THEN display "CPU: {$syssensor.cpu}%" on lcd line 1
 
 
 IF $syssensor.cpu changes or $syssensor.memory changes
-THEN display "CPU: {$syssensor.cpu}%" on lcd line 1 and display "MEM: {$syssensor.memor}MB" on lcd line 2
+THEN display "CPU: {$syssensor.cpu}%" on lcd line 1 and display "MEM: {$syssensor.memory}MB" on lcd line 2
 
 
 IF switch is turned off

--- a/lcd-config-schema.coffee
+++ b/lcd-config-schema.coffee
@@ -8,8 +8,8 @@ module.exports = {
       default: "/dev/i2c-1"
     address:
       description: "address of the device"
-      type: "number"
-      default: 0x27
+      type: "string"
+      default: "0x27"
     rows:
       description: "number of rows (lines) of the LCD"
       type: "number"

--- a/lcd.coffee
+++ b/lcd.coffee
@@ -4,15 +4,21 @@ module.exports = (env) ->
   Promise = env.require 'bluebird'
   S = env.require 'string'
   M = env.matcher
+  _ = env.require 'lodash'
+
   # Require the [cassert library](https://github.com/rhoot/cassert).
   assert = env.require 'cassert'
 
   LCD = require 'i2c-lcd'
 
   class LCDPlugin extends env.plugins.Plugin
+    prepareConfig: (config) =>
+      if _.isNumber config.address
+        config.address = "#{config.address}"
 
     init: (app, @framework, @config) =>
-      lcd = new LCD(@config.bus, @config.address)
+      # parseInt is used without the radix parameter to allow for, both, decimal and hexadecimal number strings
+      lcd = new LCD(@config.bus, parseInt @config.address)
       lcd.pendingOperation = lcd.init()
       lcd._printedLines = []
       @framework.ruleManager.addActionProvider(


### PR DESCRIPTION
- Changed address property to type "string"
- Implemented prepareConfig hook to automatically upgrade old configs with numeric address value
- Added README description

Note, prepareConfig() support for plugins needs to be implemented as part of pimatic core.
